### PR TITLE
Add simple installer for rpi-clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ only Debian packages with apt-get.
 
 #### On a Raspberry Pi:
 ```
+	Either
+	$ curl https://github.com/geerlingguy/rpi-clone/blob/master/install | sudo bash
+
+	or
 	$ git clone https://github.com/geerlingguy/rpi-clone.git
 	$ cd rpi-clone
 	$ sudo cp rpi-clone rpi-clone-setup /usr/local/sbin

--- a/install
+++ b/install
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Simple installer for rpi-clone
+#
+# Downloads and installs rpi-clone and rpi-clone-setup into /usr/local/bin
+#
+# Command to use to install rpi-clone:
+#	   curl https://github.com/geerlingguy/rpi-clone/blob/master/install | sudo bash
+#
+# rpi-clone is Copyright (c) 2018-2019 Bill Wilson
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted under the conditions of the BSD LICENSE file at
+# the rpi-clone github source repository:
+#    https://github.com/billw2/rpi-clone
+
+# This updated code is located in a fork of Bill Willsons git repository
+# at https://github.com/geerlingguy/rpi-clone
+
+set -uo pipefail
+
+readonly PACKAGE="rpi-clone"
+readonly DOWNLOAD_REPOSITORY="https://github.com/framps/rpi-clone/blob/master"
+readonly DOWNLOAD_REPOSITORY_4_MESSAGE="$(sed 's@/blob/master@@' <<< "$DOWNLOAD_REPOSITORY")"
+readonly FILES_2_DOWNLOAD"=rpi-clone rpi-clone-setup"
+readonly TMP_DIR=$(mktemp -d)
+readonly INSTALLATION_DIR="/usr/local/sbin"
+
+trap "{ rmdir $TMP_DIR &>/dev/null; }" SIGINT SIGTERM EXIT
+
+pwd=$PWD
+cd $TMP_DIR
+
+echo "Installing $PACKAGE ..."
+
+for file in $FILES_2_DOWNLOAD; do
+
+	echo -n "Downloading $file from $DOWNLOAD_REPOSITORY_4_MESSAGE ... "
+	http_code=$(curl -w "%{http_code}" -L -s $DOWNLOAD_REPOSITORY/$file -o $file)
+	(( $? )) && { echo "Curl failed"; exit 1; }
+	[[ $http_code != 200 ]] && { echo "http request failed with $http_code"; exit 1; }
+	echo "done"
+	echo -n "Installing $file into $INSTALLATION_DIR ... "
+	sudo chmod +x $file
+	(( $? )) && { echo "chmod failed"; exit 1; }
+	sudo mv $file $INSTALLATION_DIR
+	(( $? )) && { echo "mv failed"; exit 1; }
+	echo "done"
+
+done
+
+echo "$PACKAGE installed"
+cd $pwd

--- a/install
+++ b/install
@@ -20,7 +20,7 @@
 set -uo pipefail
 
 readonly PACKAGE="rpi-clone"
-readonly DOWNLOAD_REPOSITORY="https://github.com/framps/rpi-clone/blob/master"
+readonly DOWNLOAD_REPOSITORY="https://github.com/geerlingguy/rpi-clone/blob/master"
 readonly DOWNLOAD_REPOSITORY_4_MESSAGE="$(sed 's@/blob/master@@' <<< "$DOWNLOAD_REPOSITORY")"
 readonly FILES_2_DOWNLOAD"=rpi-clone rpi-clone-setup"
 readonly TMP_DIR=$(mktemp -d)


### PR DESCRIPTION
There is no need to download the whole git repo in order install rpi-clone and rpi-clone-setup. 

I created a small installer which just downloads and installs the two scripts in /usr/local/bin .