### PR TITLE
 Use temporary directories for mounting

### DIFF
--- a/rpi-clone
+++ b/rpi-clone
@@ -1010,8 +1010,8 @@ cleanup() {
 	echo "Cleaning up mounts, this might produce errors if they were already unmounted" >> "$clone_log"
 	umount "$clone" &>> "$clone_log"
 	umount "$clone_src" &>> "$clone_log"
-	rmdir "$clone"
-	rmdir "$clone_src"
+	rmdir "$clone" &>> "$clone_log"
+	rmdir "$clone_src" &>> "$clone_log"
 }
 trap cleanup EXIT
 

--- a/rpi-clone
+++ b/rpi-clone
@@ -84,9 +84,9 @@ then
 	apt-get install -y --no-install-recommends $need_packages
 fi
 
-clone=/mnt/clone
-clone_src=/mnt/clone-src
-clone_log=/var/log/$PGM.log
+export clone=/mnt/clone
+export clone_src=/mnt/clone-src
+export clone_log=/var/log/$PGM.log
 
 HOSTNAME=`hostname`
 

--- a/rpi-clone
+++ b/rpi-clone
@@ -998,7 +998,7 @@ fi
 export clone=$(mktemp --tmpdir --directory rpi-clone-dst.XXXXXX)
 export clone_src=$(mktemp --tmpdir --directory rpi-clone-src.XXXXXX)
 
-if ! [ -n "$clone" -a -d "$clone" -a -n "$clone_src" -a -d "$clone_src" ]
+if [[ -z "$clone" || ! -d "$clone" || -z "$clone_src" || ! -d "$clone_src" ]]
 then
 	echo "Failed to create temporary mount directories"
 	echo "Aborting!"
@@ -1007,8 +1007,9 @@ fi
 
 # Make sure we cleanup on exit, regardless of how we exit
 cleanup() {
-	umount "$clone" 2> /dev/null
-	umount "$clone_src" 2> /dev/null
+	echo "Cleaning up mounts, this might produce errors if they were already unmounted" >> "$clone_log"
+	umount "$clone" &>> "$clone_log"
+	umount "$clone_src" &>> "$clone_log"
 	rmdir "$clone"
 	rmdir "$clone_src"
 }

--- a/rpi-clone
+++ b/rpi-clone
@@ -84,8 +84,6 @@ then
 	apt-get install -y --no-install-recommends $need_packages
 fi
 
-export clone=/mnt/clone
-export clone_src=/mnt/clone-src
 export clone_log=/var/log/$PGM.log
 
 HOSTNAME=`hostname`
@@ -997,14 +995,24 @@ then
 	exit 0
 fi
 
-if [ ! -d $clone ]
+export clone=$(mktemp --tmpdir --directory rpi-clone-dst.XXXXXX)
+export clone_src=$(mktemp --tmpdir --directory rpi-clone-src.XXXXXX)
+
+if ! [ -n "$clone" -a -d "$clone" -a -n "$clone_src" -a -d "$clone_src" ]
 then
-	mkdir $clone
+	echo "Failed to create temporary mount directories"
+	echo "Aborting!"
+	exit 1
 fi
-if [ ! -d $clone_src ]
-then
-	mkdir $clone_src
-fi
+
+# Make sure we cleanup on exit, regardless of how we exit
+cleanup() {
+	umount "$clone" 2> /dev/null
+	umount "$clone_src" 2> /dev/null
+	rmdir "$clone"
+	rmdir "$clone_src"
+}
+trap cleanup EXIT
 
 # dst_mount_flag enumerations:
 live=1

--- a/rpi-clone
+++ b/rpi-clone
@@ -997,6 +997,15 @@ then
 	exit 0
 fi
 
+if [ ! -d $clone ]
+then
+	mkdir $clone
+fi
+if [ ! -d $clone_src ]
+then
+	mkdir $clone_src
+fi
+
 # dst_mount_flag enumerations:
 live=1
 temp=2
@@ -1251,16 +1260,6 @@ unmount_or_abort "$mounted_dev" \
 
 mounted_dev=$(findmnt /mnt -o source -n)
 unmount_or_abort "$mounted_dev" "$mounted_dev is currently mounted on /mnt."
-
-
-if [ ! -d $clone ]
-then
-	mkdir $clone
-fi
-if [ ! -d $clone_src ]
-then
-	mkdir $clone_src
-fi
 
 # Do not include a dhpys swapfile in rsync.  It regenerates at boot.
 #

--- a/rpi-clone-setup
+++ b/rpi-clone-setup
@@ -4,11 +4,13 @@
 #    eg:  sudo rpi-clone-setup bozo
 #
 # This script is automatically run by rpi-clone (when it is given -s options)
-# to setup an alternate hostname.  A cloned file system mounted on /mnt/clone
-# is expected unless testing with the -t option.
+# to setup an alternate hostname.  It expects $clone to be set in the
+# environment containing the path to a mounted cloned file system unless
+# testing with the -t option.
 #
 # Or, this script can be run by hand at the end of a clone when rpi-clone
-# pauses with the cloned file systems still mounted on /mnt/clone.
+# pauses with the cloned file systems still mounted (make sure to set
+# the $clone env variable properly, then).
 #
 # Or, run this script by hand with -t to process files in test directories
 # under /tmp/clone-test.  Run -t and look at the files to see if the files
@@ -27,7 +29,7 @@
 
 file_list="etc/hostname etc/hosts"
 
-clone=/mnt/clone
+# $clone is set by caller
 clone_test=/tmp/clone-test
 
 PGM=`basename $0`
@@ -81,9 +83,15 @@ fi
 
 echo -e "\t$newhost\t- target hostname"
 
-if ((!testing)) && [ ! -d /mnt/clone/etc ]
+if ((!testing)) && [ -z "$clone" ]
 then
-	echo "A destination clone file system is not mounted on /mnt/clone"
+	echo "No clone mountpoint was passed in the \$clone variable"
+	echo "Aborting!"
+	exit 0
+fi
+if ((!testing)) && [ ! -d "$clone/etc" ]
+then
+	echo "A destination clone file system is not mounted on $clone"
 	echo "Aborting!"
 	exit 0
 fi


### PR DESCRIPTION
This creates a temporary directory for src and dst mounts, rather than hardcoding /mnt/clone and /mnt/clone-src. This allows running the script twice in parallel, without conflicts.

To prevent littering tons of directories around, automatic cleanup of these directories is added (which has the added advantage of also unmounting and cleaning up when the script is somehow interrupted or fails in an unexpected way).

This also changes the interface to the rpi-clone-setup script slightly, since that also used to hardcode this directory name.

See commit messages for some more details.

These changes were previously submitted at https://github.com/billw2/rpi-clone/pull/102 and have been in use in my project since that PR was submitted four years ago. Now I've just rebased and reviewed them, the changes still applied without issue.