### PR TITLE
Support cloning to a loopback device

### DIFF
--- a/rpi-clone
+++ b/rpi-clone
@@ -1075,6 +1075,9 @@ then
 		else
 			assumed_fstab_edit=0
 		fi
+	elif [[ $dst_disk == *"loop"* ]]
+	then
+		dst_part_base=${dst_disk}p
 	else
 		qecho $"
   Target disk $dst_disk ends with a digit so may be a partition.


### PR DESCRIPTION
With some additional scripting around rpi-clone, this allows cloning into a loopback-mounted image file.

This is a first step towards fixing geerlingguy/rpi-clone#9.

These changes were previously submitted at https://github.com/billw2/rpi-clone/pull/179 and have been in use in my project for a year or two before that PR was submitted recently. Now I've just rebased and reviewed them, the changes still applied without issue.