### PR TITLE
Make cmdline.txt dir discovery regex more robust and use mount instead of /etc/fstab contents

### DIFF
--- a/rpi-clone
+++ b/rpi-clone
@@ -940,7 +940,12 @@ then
     exit 1
 fi
 
-cmdlinedir=$(awk '$1 !~ "^#" && $2 ~ "^/boot" && $3 == "vfat" { print substr($2, 2); exit }' /etc/fstab)
+# Starting with bookworm /boot/firmware/cmdline.txt is used. All previous RaspbianOS releases use /boot/cmdline.txt
+cmdlinedir=$(mount | awk '$3 ~ "^/boot(/firmware)?$" && $5 == "vfat" { print substr($3, 2); exit }' )
+if [[ -z "$cmdlinedir" ]]; then
+	echo "Unable to locate boot device"
+	exit 1
+fi
 
 if ((convert_to_partuuid))
 then


### PR DESCRIPTION
In https://github.com/geerlingguy/rpi-clone/issues/21 @matthijskooijman suggested to make the detection of /boot/firmware/cmdline.txt more robust.

Now the actual mount information is used to extract the information instead of the declarative contents of /etc/fstab.