### PR TITLE
Remount missing mounts of /boot and /

### DIFF
--- a/rpi-clone
+++ b/rpi-clone
@@ -296,6 +296,16 @@ rsync_file_system()
 
 	qprintf "  => lsblk $(lsblk)\n"
 
+	if ! findmnt "$src_dir" &>/dev/null; then
+		if ! mount "$src_dir"; then
+			echo "    Mount failure of $1 on $2."
+			echo "Aborting!"
+			exit 1
+		else
+			qecho "  Remounting $1"
+		fi
+	fi
+
 	qprintf "  => rsync $1 $2 $3 ..."
 
 	if [ "$3" == "with-root-excludes" ]

--- a/rpi-clone
+++ b/rpi-clone
@@ -10,9 +10,12 @@
 # This updated code is located in a fork of Bill Wilson's git repository
 # at https://github.com/geerlingguy/rpi-clone
 
-version=2.0.24
+version=2.0.23-1
 
 declare -r PS4='|${LINENO}> \011${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+
+echo "@@@ rpi5 branch version from framp @@@"
+echo
 
 # setup trusted paths for dependancies (like rsync, grub, fdisk, etc)
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/rpi-clone
+++ b/rpi-clone
@@ -298,7 +298,7 @@ rsync_file_system()
 
 	if ! findmnt "$src_dir" &>/dev/null; then
 		if ! mount "$src_dir"; then
-			echo "    Mount failure of $1 on $2."
+			echo "??? Remount failure of $1."
 			echo "Aborting!"
 			exit 1
 		else

--- a/rpi-clone
+++ b/rpi-clone
@@ -10,12 +10,10 @@
 # This updated code is located in a fork of Bill Wilson's git repository
 # at https://github.com/geerlingguy/rpi-clone
 
-version=2.0.23-1
+version=2.0.25
 
+# prefix debug statements with line numbers when -x is used 
 declare -r PS4='|${LINENO}> \011${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
-
-echo "@@@ rpi5 branch version from framp @@@"
-echo
 
 # setup trusted paths for dependancies (like rsync, grub, fdisk, etc)
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -297,8 +295,11 @@ rsync_file_system()
 	src_dir="$1"
 	dst_dir="$2"
 
-	qprintf "  => lsblk $(lsblk)\n"
+	qprintf "  => rsync $1 $2 $3 ..."
 
+	# make sure the partition is mounted
+	# sometimes it happens on RPi5 /boot is no longer mounted and then
+	# the cloned boot partition will be empty
 	if ! findmnt "$src_dir" &>/dev/null; then
 		if ! mount "$src_dir"; then
 			echo "??? Remount failure of $1."
@@ -308,8 +309,6 @@ rsync_file_system()
 			qecho "  Remounting $1"
 		fi
 	fi
-
-	qprintf "  => rsync $1 $2 $3 ..."
 
 	if [ "$3" == "with-root-excludes" ]
 	then

--- a/rpi-clone
+++ b/rpi-clone
@@ -12,6 +12,8 @@
 
 version=2.0.24
 
+declare -r PS4='|${LINENO}> \011${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+
 # setup trusted paths for dependancies (like rsync, grub, fdisk, etc)
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -291,6 +293,8 @@ rsync_file_system()
 	{
 	src_dir="$1"
 	dst_dir="$2"
+
+	qprintf "  => lsblk $(lsblk)\n"
 
 	qprintf "  => rsync $1 $2 $3 ..."
 


### PR DESCRIPTION
I think it makes sense to add the remount code for lost /boot and / mounts now. From time to time /boot is not mounted on RPi5 for some unknown reasons and then an empty /boot will be created (See #44).

In addition PS4 is now used to make flow debugging easier when option -x is used.