### PR TITLE
Copy btrfs

### DIFF
--- a/rpi-clone
+++ b/rpi-clone
@@ -1853,6 +1853,11 @@ rm -f $clone/etc/udev/rules.d/70-persistent-net.rules
 
 dst_root_vol_name=${dst_label[$root_part_num]}
 
+if [ "$dst_root_vol_name" = "" ]
+then
+	dst_root_vol_name="no label"
+fi
+
 if ((have_grub))
 then
 	qecho "grub-install --root-directory=$clone /dev/$dst_disk"

--- a/rpi-clone
+++ b/rpi-clone
@@ -1596,15 +1596,20 @@ Use -U for unattended even if initializing.
 			continue
 		fi
 
-		if [ "$fs_type" == "fat16" ]
-		then
-			mkfs_type="vfat"
-		elif [ "$fs_type" == "fat32" ]
-		then
-			mkfs_type="vfat -F 32"
-		else
-			mkfs_type=$fs_type
-		fi
+		case "$fs_type" in
+			fat16)
+				mkfs_type="vfat"
+				;;
+			fat32)
+				mkfs_type="vfat -F 32"
+				;;
+			btrfs)
+				mkfs_type="btrfs -f"
+				;;
+			*)
+				mkfs_type=$fs_type
+				;;
+		esac
 
 		if [ "${src_mounted_dir[p]}" == "/boot" ] && ((p == 1))
 		then

--- a/rpi-clone
+++ b/rpi-clone
@@ -602,7 +602,7 @@ mkfs_label()
 		vfat|msdos|exfat|fat16|fat32)
 			label_flag=-n
 			;;
-		ext2|ext3|ext4|ntfs|xfs)
+		ext2|ext3|ext4|ntfs|xfs|btrfs)
 			label_flag=-L
 			;;
 		hfs|hfsplus)
@@ -630,14 +630,31 @@ change_label()
 	dev=$3
 
 	dst_part_label "$pnum" "$fs_type" label
-	if [ "$label" != "" ] && [[ "$fs_type" == *"ext"* ]]
+	if [ "$label" != "" ] 
 	then
-		echo "     e2label $dev $label"
-		e2label $dev $label
-	elif [ "$label" != "" ] && [[ "$fs_type" == *"fat"* ]]
-	then
-		echo "     fatlabel $dev $label"
-		fatlabel $dev $label
+		case "$fs_type" in
+			vfat|msdos|exfat|fat16|fat32)
+				echo "     fatlabel $dev $label"
+				fatlabel $dev $label
+				;;
+			ext2|ext3|ext4|ntfs|xfs)
+				echo "     e2label $dev $label"
+				e2label $dev $label
+				;;
+			hfs|hfsplus)
+				echo "     Unhandled label for $dev $label"
+				;;
+			reiserfs)
+				echo "     Unhandled label for $dev $label"
+				;;
+			btrfs)
+				echo "     btrfs filesystem label $dev $label"
+				btrfs filesystem label $dev $label
+				;;
+			*)
+				echo "     Unhandled label for $dev $label"
+				;;
+		esac
 	fi
 	}
 

--- a/rpi-clone
+++ b/rpi-clone
@@ -1858,11 +1858,6 @@ rm -f $clone/etc/udev/rules.d/70-persistent-net.rules
 
 dst_root_vol_name=${dst_label[$root_part_num]}
 
-if [ "$dst_root_vol_name" = "" ]
-then
-	dst_root_vol_name="no label"
-fi
-
 if ((have_grub))
 then
 	qecho "grub-install --root-directory=$clone /dev/$dst_disk"


### PR DESCRIPTION
I added handling of btrfs. I have tested both full copying to new disk as well as refreshening old copies.
I added a force option (-f) when changing contents of existing partition to new btrfs filesystem (from ext4).
You will find interesting information on setting labels for different filesystems [here](https://wiki.archlinux.org/title/Persistent_block_device_naming#by-label). e2label is primarily for ext2/3/4 filesystem. 