### PR TITLE
Install could check for existence of INSTALLATION_DIR

### DIFF
--- a/install
+++ b/install
@@ -32,6 +32,11 @@ cd $TMP_DIR
 
 echo "Installing $PACKAGE ..."
 
+if [[ ! -d $INSTALLATION_DIR ]]; then
+       echo "ERROR: INSTALLATION_DIR ($INSTALLATION_DIR) is not a directory"
+       exit 1
+fi
+
 for file in $FILES_2_DOWNLOAD; do
 
 	echo -n "Downloading $file from $DOWNLOAD_REPOSITORY/$file ... "


### PR DESCRIPTION
I have a modified setup with a collapsed directory structure. 

Blithely trying to use the install script fails silently leaving rpi-clone-setup named /usr/local/sbin