### PR TITLE
Allow to pass an installation directory to the installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ only Debian packages with apt-get.
 ```
 $ curl https://raw.githubusercontent.com/geerlingguy/rpi-clone/master/install | sudo bash
 ```
+Default installation directory is /usr/local/sbin. If another directory should be used pass the installation directory as a parameter.
+```
+$ curl https://raw.githubusercontent.com/geerlingguy/rpi-clone/master/install | sudo bash -s -- {installationDirectory}
+```
 
 > Alternatively, you can manually install from source if you don't trust the `curl | sudo bash` install script:
 > 

--- a/install
+++ b/install
@@ -23,19 +23,21 @@ readonly PACKAGE="rpi-clone"
 readonly DOWNLOAD_REPOSITORY="https://raw.githubusercontent.com/geerlingguy/rpi-clone/master"
 readonly FILES_2_DOWNLOAD"=rpi-clone rpi-clone-setup"
 readonly TMP_DIR=$(mktemp -d)
-readonly INSTALLATION_DIR="/usr/local/sbin"
-
+readonly DEFAULT_INSTALLATION_DIR="/usr/local/sbin"
 
 pwd=$PWD
 trap "{ cd $pwd; rmdir $TMP_DIR &>/dev/null; }" SIGINT SIGTERM EXIT
 cd $TMP_DIR
 
-echo "Installing $PACKAGE ..."
+installDir="${1:-$DEFAULT_INSTALLATION_DIR}"
 
-if [[ ! -d $INSTALLATION_DIR ]]; then
-       echo "ERROR: INSTALLATION_DIR ($INSTALLATION_DIR) is not a directory"
+if [[ ! -d $installDir ]]; then
+       echo "Installation directory $installDir not found"
+       echo "Pass a valid installation directory as a parameter to $0"
        exit 1
 fi
+
+echo "Installing $PACKAGE into $installDir ..."
 
 for file in $FILES_2_DOWNLOAD; do
 
@@ -44,10 +46,10 @@ for file in $FILES_2_DOWNLOAD; do
 	(( $? )) && { echo "Curl failed"; exit 1; }
 	[[ $http_code != 200 ]] && { echo "http request failed with $http_code"; exit 1; }
 	echo "done"
-	echo -n "Installing $file into $INSTALLATION_DIR ... "
+	echo -n "Installing $file into $installDir ... "
 	sudo chmod +x $file
 	(( $? )) && { echo "chmod failed"; exit 1; }
-	sudo mv $file $INSTALLATION_DIR
+	sudo mv $file $installDir
 	(( $? )) && { echo "mv failed"; exit 1; }
 	echo "done"
 

--- a/install
+++ b/install
@@ -2,7 +2,7 @@
 
 # Simple installer for rpi-clone
 #
-# Downloads and installs rpi-clone and rpi-clone-setup into /usr/local/bin
+# Downloads and installs rpi-clone and rpi-clone-setup into /usr/local/sbin
 #
 # Command to use to install rpi-clone:
 #	   curl https://raw.githubusercontent.com/geerlingguy/rpi-clone/master/install | sudo bash


### PR DESCRIPTION
Default installation directory is /usr/local/sbin. If this directory does not exist and/or another directory should be used a parameter is accepted by the installer which defines the installation directory.