### PR TITLE
Ignore and suppress some label messages

### DIFF
--- a/rpi-clone
+++ b/rpi-clone
@@ -536,13 +536,13 @@ change_label() {
 
     dst_part_label "$pnum" "$fs_type" label
     if [ "$label" != "" ] && [[ "$fs_type" == *"ext"* ]]; then
-        if [ $(e2label $dev) != "$label" ]; then
-            echo "  e2label $dev $label"
+        if [ $(e2label "$dev" | grep "$label") != "$label" ]; then
+            qecho "  e2label $dev $label"
             e2label $dev $label
         fi
     elif [ "$label" != "" ] && [[ "$fs_type" == *"fat"* ]]; then
-        if [ $(fatlabel $dev) != "$label" ]; then
-            echo "  fatlabel $dev $label"
+        if [ $(fatlabel "$dev" | grep "$label") != "$label" ]; then
+            qecho "  fatlabel $dev $label"
             fatlabel $dev $label
         fi
     fi


### PR DESCRIPTION
Updated code according @pcollinson s proposal and replaced echo with qecho to suppress the messages when option `-q` is used.

@geerlingguy I don't think it's required to bump the version number.