### PR TITLE
Fixed syntax error in if statements due to missing operand quoting

### DIFF
--- a/rpi-clone
+++ b/rpi-clone
@@ -536,12 +536,12 @@ change_label() {
 
     dst_part_label "$pnum" "$fs_type" label
     if [ "$label" != "" ] && [[ "$fs_type" == *"ext"* ]]; then
-        if [ $(e2label "$dev" | grep "$label") != "$label" ]; then
+        if [ "$(e2label "$dev" | grep -F -e "$label")" != "$label" ]; then
             qecho "  e2label $dev $label"
             e2label $dev $label
         fi
     elif [ "$label" != "" ] && [[ "$fs_type" == *"fat"* ]]; then
-        if [ $(fatlabel "$dev" | grep "$label") != "$label" ]; then
+        if [ "$(fatlabel "$dev" | grep -F -e "$label")" != "$label" ]; then
             qecho "  fatlabel $dev $label"
             fatlabel $dev $label
         fi


### PR DESCRIPTION
Fixed syntax error "unary operator expected" in if statements at lines 539 and 544 due to missing operand quoting.

The error was introduced in [Commit 8ee6ff7](https://github.com/geerlingguy/rpi-clone/commit/8ee6ff7a0b62d43632466ad3fb6a048b01953f6f).

The issue occurs when rpi-clone checks if it needs to set a partition label. That is line 544 in rpi-clone:

` if [ $(fatlabel "$dev" | grep "$label") != "$label" ]; then`

In the rpi-clone output, the error reads:

`/opt/rpi-clone/rpi-clone: line 544: [: !=: unary operator expected`

Also, in my case, the label on the boot partition was set to "--":

```
rpi-clone Version: 2.0.27

Booted disk: mmcblk0 31.9GB                Destination disk: sdc 32.0GB
---------------------------------------------------------------------------
Part               Size    FS     Label           Part   Size    FS     Label
1 /boot/firmware   512.0M  fat32  --              1      512.0M  fat32  --
2 root              29.2G  ext4   filesrv         2       29.3G  ext4   filesrv
---------------------------------------------------------------------------
```

The label "--" created issues with the grep command. The use of "-F -e" options allows grep to work as expected.

The proposed fix:
- Prevent syntax crashes when labels are missing or empty (via double-quoting).
- Fix search errors when labels contain characters like dashes or are empty (via grep -F -e).

I successfully tested the fix in my setup before and after changing the boot partition label from "--" to a more standard "BOOT".

Note that the same issue affecting line 544 also affects line 539. Therefore I applied the same fix there too.